### PR TITLE
Add a README regeneration script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    name: Checks with no code execution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Install the latest Python version
+        using: actions/setup-python@v3
+        with:
+          cache: pip
+      - name: Install tools
+        run: python -m pip install wemake-python-styleguide
+      - name: Test for code style
+        # Ignore "WPS305 Found `f` string" 
+        run: flake8 --ignore=WPS305 .

--- a/README.md
+++ b/README.md
@@ -32,15 +32,13 @@ constantly meet lags and crashes.
 Systematic contributions:
 
 - Python interpreter:
-  - **python/cpython**: [17 already merged commits](https://github.com/python/cpython/commits?author=arhadthedev), [9 PRs are awaiting review](https://github.com/python/cpython/pulls/arhadthedev), [5 reported issues](https://github.com/python/cpython/issues?q=is%3Aissue+author%3Aarhadthedev) (starting with April 14, 2022)
+  - **python/cpython**: [17 already merged commits](https://github.com/python/cpython/commits?author=arhadthedev), [9 PRs are awaiting review](https://github.com/python/cpython/pulls/arhadthedev), [5 reported issues](https://github.com/python/cpython/issues?q=is%3Aissue+author%3Aarhadthedev)
   - **python/core-workflow**: [1 PR is awaiting review](https://github.com/python/core-workflow/pulls/arhadthedev)
   - **python/bedevere**: [1 already merged commit](https://github.com/python/bedevere/commits?author=arhadthedev)
   - **sphinx-contrib/sphinx-lint**: [1 already merged commit](https://github.com/sphinx-contrib/sphinx-lint/commits?author=arhadthedev)
 
 - ECMAScript (aka JavaScript) specification:
   - **tc39/ecma262**: [1 already merged commit](https://github.com/tc39/ecma262/commits?author=arhadthedev), [1 PR is awaiting review](https://github.com/tc39/ecma262/pulls/arhadthedev)
-
-Last updated 2022-05-13.
 
 
 ### GitHub Stats

--- a/regen_readme.py
+++ b/regen_readme.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Regenerate Open Source section of README.md using prepared statistics.
+
+The statistics are supplied by a JSON file with a dictionary:
+
+.. code-block:: json
+
+    {
+        "author": "<a GitHub username of a user that the file describes>",
+        "<repo-org/repo-name>": {
+            "commit_count": <number>,
+            "open_pr_count": <number>,
+            "issue_count": <number>
+        }
+    }
+"""
+
+import json
+import re
+from argparse import ArgumentParser
+from functools import partial
+from pathlib import Path
+
+
+def _make_contrib_highlight(templates) -> str | None:
+    count, url, plural_template, message_template = templates
+    if count() > 0:
+        plural = plural_template(count())
+        return message_template.format(count=count(), plural=plural, url=url)
+
+
+def _make_contrib_line(contribs, match: re.Pattern) -> str:
+    repo_name = match.group('name')
+    repo_path = f'https://github.com/{repo_name}'
+
+    generators = [
+        (
+            lambda: contribs[repo_name].get('commit_count', 0),
+            f'{repo_path}/commits?author={contribs["author"]}',
+            lambda count: 's' if count > 1 else '',
+            '[{count} already merged commit{plural}]({url})',
+        ),
+        (
+            lambda: contribs[repo_name].get('pr_count', 0),
+            f'{repo_path}/pulls/{contribs["author"]}',
+            lambda count: 's are' if count > 1 else ' is',
+            '[{count} PR{plural} awaiting review]({url})',
+        ),
+        (
+            lambda: contribs[repo_name].get('issue_count', 0),
+            f'{repo_path}/issues?q=is%3Aissue+author%3A{contribs["author"]}',
+            lambda count: 's' if count > 1 else '',
+            '[{count} reported issue{plural}]({url})',
+        ),
+    ]
+
+    all_entries = map(_make_contrib_highlight, generators)
+    contrib_statistics = ', '.join(filter(None, all_entries))
+    return f'  - **{repo_name}**: {contrib_statistics}'
+
+
+_contrib_regex = re.compile(
+    r'^  - \*\*(?P<name>[a-zA-Z0-9_]+/[a-zA-Z0-9_]+)\*\*:.*$',
+    re.MULTILINE,
+)
+
+
+def _update_readme(source_file: Path) -> None:
+    readme_file = Path('README.md')
+    contribs = json.loads(source_file.read_text(encoding='utf8'))
+
+    line_updater = partial(_make_contrib_line, contribs)
+    original_readme = readme_file.read_text(encoding='utf8')
+    updated_readme = _contrib_regex.sub(line_updater, original_readme)
+    readme_file.write_text(updated_readme, encoding='utf8')
+
+
+def _get_cli_inputs() -> Path:
+    parser = ArgumentParser(description='Regenerate README.md.')
+    parser.add_argument(
+        'source',
+        type=Path,
+        help='Path to a JSON file with actual source data.',
+    )
+    args = parser.parse_args()
+    return args.source
+
+
+if __name__ == '__main__':
+    source_file = _get_cli_inputs()
+    _update_readme(source_file)


### PR DESCRIPTION
Generate README.md from a json file. The file generation will be added in some latter commit.

As a proof of concept, a generated file is attached. The source data for generation:

```json
{
    "author": "arhadthedev",
    "python/cpython": {
        "commit_count": 17,
        "pr_count": 9,
        "issue_count": 5
    },
    "python/core-workflow": {
        "pr_count": 1
    },
    "python/bedevere": {
        "commit_count": 1
    },
    "sphinx-contrib/sphinx-lint": {
        "commit_count": 1
    },
    "tc39/ecma262": {
        "commit_count": 1,
        "pr_count": 1
    }
}
```

A part of #3.