### PR TITLE
Fix "review" to more correct "merging"

### DIFF
--- a/regen_readme.py
+++ b/regen_readme.py
@@ -46,7 +46,7 @@ def _make_contrib_line(contribs, match: re.Pattern) -> str:
             lambda: contribs[repo_name].get('pr_count', 0),
             f'{repo_path}/pulls/{contribs["author"]}',
             lambda count: 's are' if count > 1 else ' is',
-            '[{count} PR{plural} awaiting review]({url})',
+            '[{count} PR{plural} awaiting merging]({url})',
         ),
         (
             lambda: contribs[repo_name].get('issue_count', 0),


### PR DESCRIPTION
Currently, README marks all unclosed pull requests as *awaiting review*. However, this wording leaves an impression that the PRs are not even visited once which is false. In reality, CPython PRs have a month long window of feedback gathering.