### PR TITLE
Remove outdated "I’m looking for" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ API is partially synchronous and has thick multilayer wrappers for
 compatibility I don’t need. However, this knowledge has no use if the
 application is for Windows Store.
 - 👯 I’m looking to collaborate on C or C++ desktop or network backend projects.
-- 🤔 I’m looking for help with searching of Russia-hosted analog of Google
-Firebase for my Russia-only projects because of ping.
+- 🤔 I’m looking for [REDACTED].
 - 💬 Ask me about mitigation of C qirks, how to port a static site to an ad-hoc
 Python generator, and how to preserve sanity in the process.
 - 📫 How to reach me:


### PR DESCRIPTION
I found the hosting, so leave an SCP easter egg behind.