### PR TITLE
Upload collect_contribs.py output for debugging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             > stats.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload build artifacts
+      - name: Upload raw statistics retrieved from GitHub
         uses: actions/upload-artifact@v3
         with:
           name: Raw statistics from GitHub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,11 @@ jobs:
             > stats.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Raw statistics from GitHub
+          path: stats.json
       - name: Update README.md
         run: ./regen_readme.py stats.json
       - name: Upload build artifacts


### PR DESCRIPTION
gh-20:

> The *Open Source* section of the profile README reports:
>
> >Python interpreter:
> >
> > [...]
> >
>
> However, the link shows two PRs, *Loosen README check for CPython forks* and *Remove `blurb split`; after 3.2 NEWS is generated from next/*, not vice versa*.

This PR is a provisional way to debug whether it's a misquery to GitHub or the `python/core-workflow` is just ignored.