### PR TITLE
Fix skipping of repository names with dashes

### DIFF
--- a/regen_readme.py
+++ b/regen_readme.py
@@ -62,7 +62,7 @@ def _make_contrib_line(contribs, match: re.Pattern) -> str:
 
 
 _contrib_regex = re.compile(
-    r'^  - \*\*(?P<name>[a-zA-Z0-9_]+/[a-zA-Z0-9_]+)\*\*:.*$',
+    r'^  - \*\*(?P<name>[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)\*\*:.*$',
     re.MULTILINE,
 )
 


### PR DESCRIPTION
Initial regex: 
https://github.com/arhadthedev/arhadthedev/blob/9f6a0d1e8d3a397fc955846c6218c69b686e4534/regen_readme.py#L65

skipped names like `python/core-workflow` because `[a-zA-Z0-9_]` does not includes dashes.

Fixes gh-20.