### PR TITLE
Add manual README regeneration

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     # The string is composed using <https://crontab.guru/>
     - cron: '0 0 * * 1'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
In case of some outstanding sprawl/contraction of PRs it may be worth to update the README prematurely. 

The same applies to debugging sessions when there's a suspision on missing entries.