### PR TITLE
Add gathering README statistics from repos with any default branch

### DIFF
--- a/collect_contribs.py
+++ b/collect_contribs.py
@@ -58,7 +58,7 @@ query_template_raw = """
       issues(after: "1", filterBy: {{createdBy: $user}}) {{
         totalCount
       }}
-      commits: object(expression: "main or master") {{
+      commits: object(expression: "HEAD") {{
         ... on Commit {{
           history(author: {{emails: $emails}}) {{
             totalCount

--- a/collect_contribs.py
+++ b/collect_contribs.py
@@ -58,7 +58,7 @@ query_template_raw = """
       issues(after: "1", filterBy: {{createdBy: $user}}) {{
         totalCount
       }}
-      commits: object(expression: "main") {{
+      commits: object(expression: "main or master") {{
         ... on Commit {{
           history(author: {{emails: $emails}}) {{
             totalCount


### PR DESCRIPTION
Currently, the README generation script looks for `main` branch only to emit `X already merged commits` lines.

However, `python` organization also has repos with `master` default branch that is unexpected by the script. As a result, commit count for non-existent `main` is reported as zero there.

Closes gh-25.