### PR TITLE
Fix Something Went Wrong of github-readme-stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ I also randomly contribute to any repository I use in my code: [issues](htt
 
 Generated by [anuraghazra/github-readme-stats](https://github.com/anuraghazra/github-readme-stats):
 
-![Arhadthedev’s GitHub stats](https://github-readme-stats.vercel.app/api?username=arhadthedev&show_icons=true)
-![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=arhadthedev&layout=compact&exclude_repo=qt-4.3.5,unrealwiki-offline-20080405,uttexture-20140808,beyondunreal-wiki-20161217)
+![Arhadthedev’s GitHub stats](https://github-readme-stats-ruby-one.vercel.app/api?username=arhadthedev&show_icons=true)
+![Top Langs](https://github-readme-stats-ruby-one.vercel.app/api/top-langs/?username=arhadthedev&layout=compact&exclude_repo=qt-4.3.5,unrealwiki-offline-20080405,uttexture-20140808,beyondunreal-wiki-20161217)
 
 
 ### Useful third party online tools I use


### PR DESCRIPTION
According to https://github.com/anuraghazra/github-readme-stats/issues/2405#issuecomment-1383125516, the backend of anuraghazra/github-readme-stats moved from `https://github-readme-stats.vercel.app` to `https://github-readme-stats-ruby-one.vercel.app`.