### PR TITLE
Fix broken github-readme-stats, attempt 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ I also randomly contribute to any repository I use in my code: [issues](htt
 
 Generated by [anuraghazra/github-readme-stats](https://github.com/anuraghazra/github-readme-stats):
 
-![Arhadthedev’s GitHub stats](https://github-readme-stats-ruby-one.vercel.app/api?username=arhadthedev&show_icons=true)
-![Top Langs](https://github-readme-stats-ruby-one.vercel.app/api/top-langs/?username=arhadthedev&layout=compact&exclude_repo=qt-4.3.5,unrealwiki-offline-20080405,uttexture-20140808,beyondunreal-wiki-20161217)
+![Arhadthedev’s GitHub stats](github-readme-stats.zohan.tech)
+![Top Langs](github-readme-stats.zohan.tech/api/top-langs/?username=arhadthedev&layout=compact&exclude_repo=qt-4.3.5,unrealwiki-offline-20080405,uttexture-20140808,beyondunreal-wiki-20161217)
 
 
 ### Useful third party online tools I use

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ I also randomly contribute to any repository I use in my code: [issues](htt
 
 Generated by [anuraghazra/github-readme-stats](https://github.com/anuraghazra/github-readme-stats):
 
-![Arhadthedev’s GitHub stats](github-readme-stats.zohan.tech)
-![Top Langs](github-readme-stats.zohan.tech/api/top-langs/?username=arhadthedev&layout=compact&exclude_repo=qt-4.3.5,unrealwiki-offline-20080405,uttexture-20140808,beyondunreal-wiki-20161217)
+![Arhadthedev’s GitHub stats](https://github-readme-stats.zohan.tech/api?username=arhadthedev&show_icons=true)
+![Top Langs](https://github-readme-stats.zohan.tech/api/top-langs/?username=arhadthedev&layout=compact&exclude_repo=qt-4.3.5,unrealwiki-offline-20080405,uttexture-20140808,beyondunreal-wiki-20161217)
 
 
 ### Useful third party online tools I use


### PR DESCRIPTION
After #30 migrated *GitHub Stats* section of the profile README to https://github-readme-stats-ruby-one.vercel.app, quota exhaustion errors got replaced with site unavailability errors.

This PR switches to the next currently working mirror from `https://github.com/anuraghazra/github-readme-stats/issues/2415#issuecomment-1398201811`.