### PR TITLE
Change the contribution stats update to monthly

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Weekly Update
+name: Monthly Update
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
   schedule:
     # The string is composed using <https://crontab.guru/>
-    - cron: '0 0 * * 1'
+    - cron: '0 0 1 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
After I became a Python issue triager I got lesser possibilities to code. As a result, ±1 weekly progress will just clutter the Git history. For noticeable changes is's better to update the README monthly.