### PR TITLE
gh-98: Update CPython from 3.11 to 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ jobs:
   readme:
     name: Generate README
     runs-on: ubuntu-latest
+    permissions:
+      # setup-python access to check out code and install dependencies
+      contents: read
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -16,7 +19,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: pip
-          python-version: 3.11
+          python-version: 3.13
       - name: Install dependencies
         run: python -m pip install -r requirements.txt
       - name: Gather contribution statistics


### PR DESCRIPTION
Python 3.12 and 3.13 add no language features relevant for us. So we change a single `actions/setup-python` parameter and adjust the CI permissions
[as recommended](https://github.com/actions/setup-python/blob/5db1cf9a/README.md):

> **Recommended permissions**
>
> When using the setup-python action in your GitHub Actions workflow,
> it is recommended to set the following permissions to ensure proper
> functionality:
>
> ```yaml
> permissions:
>   contents: read # access to check out code and install dependencies
> ```

- Issue: gh-98