### PR TITLE
gh-98: Enable colored output for Python on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ env:
   # $TERM is required for $FORCE_COLOR but absent on GitHub CI.
   # See <https://github.com/python/mypy/issues/13817> for details.
   #
-  # Discovered via <https://github.com/python/cpython/blob/e6c3039c/.github/workflows/mypy.yml#L35-L36>
+  # Discovered via <https://github.com/python/cpython/blob/e6c3039c/.github/workflows/mypy.yml#L35-L36>.
   TERM: xterm-256color
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
   workflow_call:
 
+env:
+  FORCE_COLOR: 1
+  # $TERM is required for $FORCE_COLOR but absent on GitHub CI.
+  # See <https://github.com/python/mypy/issues/13817> for details.
+  #
+  # Discovered via <https://github.com/python/cpython/blob/e6c3039c/.github/workflows/mypy.yml#L35-L36>
+  TERM: xterm-256color
+
 jobs:
   readme:
     name: Generate README


### PR DESCRIPTION
Python 3.13 has console output coloration. Non-console stdout like the one on CI should explicitly enable coloration control codes.

- Issue: gh-98