### PR TITLE
gh-106: Add Ruff into the CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,9 @@ jobs:
   check-python:
     name: Checks Python code with no execution
     runs-on: ubuntu-latest
+    permissions:
+      # setup-python access to check out code and install dependencies
+      contents: read
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -27,9 +30,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: pip
-          python-version: 3.11
+          cache-dependency-path: github_readme
+          python-version: 3.13
       - name: Install tools
-        run: python -m pip install wemake-python-styleguide
+        run: python -m pip install ruff
       - name: Test for code style
-        # Ignore "WPS305 Found `f` string" 
-        run: flake8 --ignore=WPS305 .
+        run: python -mruff check github_readme

--- a/github_readme/pyproject.toml
+++ b/github_readme/pyproject.toml
@@ -35,5 +35,30 @@ dependencies = [
 requires = ["setuptools >= 61.0.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.ruff]
+target-version = "py313"
+# PEP 8
+line-length = 79
+
+[tool.ruff.lint]
+select = ["ALL"]
+
+ignore = [
+  "Q000", # We use single quotes for now
+  "RUF001", # We use a text editor that shows NBSP as <0xa0>, not a plain space
+
+  # TODO: fix, remove, and tick the bullet points in gh-106
+  "D212",
+  "D213",
+  "ANN001",
+  "ANN202",
+  "G001",
+  "LOG015",
+  "RET503",
+  "UP009",
+  "UP030",
+  "UP032",
+]
+
 [tool.setuptools]
 py-modules = ["collect_contribs", "regen_readme"]


### PR DESCRIPTION
Instead of fixing newfound errors we add them into the skip list to fix later.

Note: Ruff needs the latest Python to analyze import types effectively.

- Issue: gh-106