### PR TITLE
gh-106: Fix Ruff error G001

### DIFF
--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -109,7 +109,7 @@ _user_agent = 'arhadthedev/arhadthedev'
 
 async def _make_query(query, emails: list[str], user: str, token: str):
     query_names, query_string = query
-    debug('A query to be sent: {0}'.format(query_string))
+    debug('A query to be sent: %s', query_string)
     async with ClientSession() as session:
         gh = GitHubAPI(session, _user_agent, oauth_token=token)
         gh_response = await gh.graphql(query_string, user=user, emails=emails)

--- a/github_readme/pyproject.toml
+++ b/github_readme/pyproject.toml
@@ -50,7 +50,6 @@ ignore = [
   # TODO: fix, remove, and tick the bullet points in gh-106
   "ANN001",
   "ANN202",
-  "G001",
   "LOG015",
   "RET503",
   "UP009",


### PR DESCRIPTION
From <https://docs.astral.sh/ruff/rules/logging-string-format/>:

> **What it does**
>
> Checks for uses of `str.format` to format logging messages.
>
> **Why is this bad?**
>
> The logging module provides a mechanism for passing additional values to be logged using the extra keyword argument. This is more consistent, more efficient, and less error-prone than formatting the string directly.
>
> [...]
>
> Additionally, the use of extra will ensure that the values are made available to all handlers, which can then be configured to log the values in a consistent manner.

- Issue: gh-106