### PR TITLE
gh-106: Fix Ruff incompatible rule warnings

### DIFF
--- a/github_readme/pyproject.toml
+++ b/github_readme/pyproject.toml
@@ -44,6 +44,8 @@ line-length = 79
 select = ["ALL"]
 
 ignore = [
+  "D203", # Conflicts with D211 modelled after PEP-257
+  "D213", # Conflicts with D212 modelled after PEP-257
   "Q000", # We use single quotes for now
   "RUF001", # We use a text editor that shows NBSP as <0xa0>, not a plain space
 


### PR DESCRIPTION
Fix two warnings:

> warning: `incorrect-blank-line-before-class` (D203)
> and `no-blank-line-before-class` (D211) are incompatible. Ignoring
> `incorrect-blank-line-before-class`.

> warning: `multi-line-summary-first-line` (D212)
> and `multi-line-summary-second-line` (D213) are incompatible. Ignoring
> `multi-line-summary-second-line`.

- Issue: gh-106