### PR TITLE
gh-106: Fix Ruff error LOG015

### DIFF
--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -15,14 +15,15 @@ import os
 import re
 from argparse import ArgumentParser
 from asyncio import run
-from logging import basicConfig, debug
+from logging import getLogger
 from sys import stdout
 
 from aiohttp import ClientSession
 from gidgethub.aiohttp import GitHubAPI
 
 LOGLEVEL = os.environ.get('LOGLEVEL', 'INFO').upper()
-basicConfig(level=LOGLEVEL)
+logger = getLogger(__name__)
+logger.setLevel(LOGLEVEL)
 
 
 def _get_inputs() -> tuple[str, str, str]:
@@ -109,7 +110,7 @@ _user_agent = 'arhadthedev/arhadthedev'
 
 async def _make_query(query, emails: list[str], user: str, token: str):
     query_names, query_string = query
-    debug('A query to be sent: %s', query_string)
+    logger.debug('A query to be sent: %s', query_string)
     async with ClientSession() as session:
         gh = GitHubAPI(session, _user_agent, oauth_token=token)
         gh_response = await gh.graphql(query_string, user=user, emails=emails)

--- a/github_readme/pyproject.toml
+++ b/github_readme/pyproject.toml
@@ -52,7 +52,6 @@ ignore = [
   # TODO: fix, remove, and tick the bullet points in gh-106
   "ANN001",
   "ANN202",
-  "LOG015",
   "RET503",
   "UP009",
   "UP030",


### PR DESCRIPTION
From <https://docs.astral.sh/ruff/rules/root-logger-call/>:

> **What it does**
>
> Checks for usages of the following logging top-level functions:
> `debug`, `info`, `warn`, `warning`, `error`, `critical`, `log`,
> `exception`.
>
> **Why is this bad?**
>
> Using the root logger causes the messages to have no source
> information, making them less useful for debugging.

- Issue: gh-106