### PR TITLE
gh-106: Fix Ruff error RET503

### DIFF
--- a/github_readme/pyproject.toml
+++ b/github_readme/pyproject.toml
@@ -52,7 +52,6 @@ ignore = [
   # TODO: fix, remove, and tick the bullet points in gh-106
   "ANN001",
   "ANN202",
-  "RET503",
   "UP030",
   "UP032",
 ]

--- a/github_readme/regen_readme.py
+++ b/github_readme/regen_readme.py
@@ -28,6 +28,7 @@ def _make_contrib_highlight(templates) -> str | None:
     if count() > 0:
         plural = plural_template(count())
         return message_template.format(count=count(), plural=plural, url=url)
+    return None
 
 
 def _make_contrib_line(contribs, match: re.Pattern) -> str:


### PR DESCRIPTION
From <https://docs.astral.sh/ruff/rules/implicit-return/>:

> **What it does**
>
> Checks for missing explicit `return` statements at the end
> of functions that can return non-`None` values.
>
> **Why is this bad?**
>
> The lack of an explicit `return` statement at the end of a function
> that can return non-None values can cause confusion. Python implicitly
> returns `None` if no other return value is present. Adding an explicit
> `return None` can make the code more readable by clarifying intent.

- Issue: gh-106