### PR TITLE
gh-106: Update status on Ruff errors UP030 and UP032

### DIFF
--- a/github_readme/pyproject.toml
+++ b/github_readme/pyproject.toml
@@ -52,8 +52,6 @@ ignore = [
   # TODO: fix, remove, and tick the bullet points in gh-106
   "ANN001",
   "ANN202",
-  "UP030",
-  "UP032",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
In gh-112 (46cde506) we removed the cause of these two errors (`str.format` call).

From <https://docs.astral.sh/ruff/rules/format-literals/>:

> **What it does**
>
> Checks for unnecessary positional indices in format strings.
>
> **Why is this bad?**
>
> In Python 3.1 and later, format strings can use implicit positional
> references. For example, `"{0}, {1}".format("Hello", "World")` can be
> rewritten as `"{}, {}".format("Hello", "World")`.

From <https://docs.astral.sh/ruff/rules/f-string/>:

> **What it does**
>
> Checks for `str.format` calls that can be replaced with f-strings.
>
> **Why is this bad?**
>
> f-strings are more readable and generally preferred over `str.format`
> calls.

- Issue: gh-106