### PR TITLE
gh-106: Update status on Ruff errors ANN001

### DIFF
--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -15,6 +15,7 @@ import os
 import re
 from argparse import ArgumentParser
 from asyncio import run
+from io import TextIOBase
 from logging import getLogger
 from sys import stdout
 
@@ -109,8 +110,12 @@ _user_agent = 'arhadthedev/arhadthedev'
 
 type NestedDict[T] = dict[str, T | 'NestedDict[T]']
 
-async def _make_query(query: dict[str, str], emails: list[str], user: str,
-    token: str) -> tuple[str, list[str], NestedDict[str]]:
+async def _make_query(
+    query: dict[str, str],
+    emails: list[str],
+    user: str,
+    token: str,
+) -> tuple[str, list[str], NestedDict[str]]:
     query_names, query_string = query
     logger.debug('A query to be sent: %s', query_string)
     async with ClientSession() as session:
@@ -119,7 +124,11 @@ async def _make_query(query: dict[str, str], emails: list[str], user: str,
         return user, query_names, gh_response
 
 
-def _condense_report(user: str, query_names, gh) -> dict[str, str]:
+def _condense_report(
+    user: str,
+    query_names: list[str],
+    gh: NestedDict[str],
+) -> dict[str, str]:
     condenced = {'author': user}
     for name, field_id in query_names.items():
         if gh[field_id]['commits'] is None:
@@ -134,7 +143,10 @@ def _condense_report(user: str, query_names, gh) -> dict[str, str]:
     return condenced
 
 
-def _output_results(statistics, output) -> None:
+def _output_results(
+    statistics: tuple[str, list[str], NestedDict[str]],
+    output: TextIOBase,
+) -> None:
     user, query_names, gh = statistics
     condenced = _condense_report(user, query_names, gh)
     output.write(json.dumps(condenced))

--- a/github_readme/pyproject.toml
+++ b/github_readme/pyproject.toml
@@ -48,9 +48,6 @@ ignore = [
   "D213", # Conflicts with D212 modelled after PEP-257
   "Q000", # We use single quotes for now
   "RUF001", # We use a text editor that shows NBSP as <0xa0>, not a plain space
-
-  # TODO: fix, remove, and tick the bullet points in gh-106
-  "ANN001",
 ]
 
 [tool.setuptools]

--- a/github_readme/regen_readme.py
+++ b/github_readme/regen_readme.py
@@ -19,11 +19,14 @@ The statistics are supplied by a JSON file with a dictionary:
 import json
 import re
 from argparse import ArgumentParser
+from collections.abc import Callable
 from functools import partial
 from pathlib import Path
 
 
-def _make_contrib_highlight(templates) -> str | None:
+def _make_contrib_highlight(
+    templates: tuple[int, str, Callable[[int], str], str],
+) -> str | None:
     count, url, plural_template, message_template = templates
     if count() > 0:
         plural = plural_template(count())
@@ -31,7 +34,10 @@ def _make_contrib_highlight(templates) -> str | None:
     return None
 
 
-def _make_contrib_line(contribs, match: re.Pattern) -> str:
+type NestedDict[T] = dict[str, T | "NestedDict[T]"]
+
+
+def _make_contrib_line(contribs: NestedDict[str], match: re.Pattern) -> str:
     repo_name = match.group('name')
     repo_path = f'https://github.com/{repo_name}'
 


### PR DESCRIPTION
From <https://docs.astral.sh/ruff/rules/missing-type-function-argument/>:

> **What it does**
>
> Checks that function arguments have type annotations.
>
> **Why is this bad?**
>
> Type annotations are a good way to document the return types
> of functions. They also help catch bugs, when used alongside a type
> checker, by ensuring that the types of any returned values,
> and the types expected by callers, match expectation.

- Issue: gh-106