### PR TITLE
gh-118: Abandon removal of query line breaks and empty lines

### DIFF
--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -55,7 +55,7 @@ def _make_id(parsed_name: list[str]) -> str:
     return parsed_name[1].replace('-', '')
 
 
-query_template_raw = """
+query_template = """
     query ($user: String!, $emails: [String!]) {{
       {subqueries}
     }}
@@ -76,7 +76,7 @@ query_template_raw = """
     }}
 """
 
-subquery_template_raw = """
+subquery_template = """
     {slug}: repository(name: "{repo}", owner: "{org}") {{
       ...ContributionsFragment
     }}
@@ -91,9 +91,6 @@ subquery_template_raw = """
 
 
 def _get_query(repositories: list[str]) -> tuple[dict[str, str], str]:
-    query_template = re.sub('\n| (?= )', '', query_template_raw)
-    subquery_template = re.sub('\n| (?= )', '', subquery_template_raw)
-
     parsed_names = {name: name.split('/', maxsplit=1) for name in repositories}
     name_to_id = {name: _make_id(parsed_names[name]) for name in repositories}
     subqueries = [

--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -12,7 +12,6 @@ and joining everything like the filter is originally supported.
 
 import json
 import os
-import re
 from argparse import ArgumentParser
 from asyncio import run
 from io import TextIOBase


### PR DESCRIPTION
GraphQL is already designed around formatted requests with newlines and spaces so we actually need no request size reduction.

- Issue: gh-118