### PR TITLE
gh-118: Normalize the query

### DIFF
--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -77,7 +77,7 @@ subquery_template = """
       ...ContributionsFragment
     }}
     {slug}Pulls: search(
-      query: "repo:{org}/{repo} is:pr is:open author:arhadthedev"
+      query: "repo:{org}/{repo} is:pr is:open author:$user"
       type: ISSUE
       first: 1
     ) {{
@@ -113,6 +113,7 @@ async def _make_query(
     logger.warning('A query to be sent: %s', query_string)
     async with ClientSession() as session:
         gh = GitHubAPI(session, _user_agent, oauth_token=token)
+        logger.warning("user: %s", user)
         gh_response = await gh.graphql(query_string, user=user, emails=emails)
         return user, query_names, gh_response
 

--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -21,7 +21,7 @@ from sys import stdout
 from aiohttp import ClientSession
 from gidgethub.aiohttp import GitHubAPI
 
-LOGLEVEL = os.environ.get('LOGLEVEL', 'DEBUG').upper()
+LOGLEVEL = os.environ.get('LOGLEVEL', 'INFO').upper()
 logger = getLogger(__name__)
 logger.setLevel(LOGLEVEL)
 
@@ -110,7 +110,7 @@ async def _make_query(
     token: str,
 ) -> tuple[str, list[str], NestedDict[str]]:
     query_names, query_string = query
-    logger.debug('A query to be sent: %s', query_string)
+    logger.info('A query to be sent: %s', query_string)
     async with ClientSession() as session:
         gh = GitHubAPI(session, _user_agent, oauth_token=token)
         gh_response = await gh.graphql(query_string, user=user, emails=emails)

--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -21,7 +21,7 @@ from sys import stdout
 from aiohttp import ClientSession
 from gidgethub.aiohttp import GitHubAPI
 
-LOGLEVEL = os.environ.get('LOGLEVEL', 'INFO').upper()
+LOGLEVEL = os.environ.get('LOGLEVEL', 'DEBUG').upper()
 logger = getLogger(__name__)
 logger.setLevel(LOGLEVEL)
 

--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -69,9 +69,6 @@ query_template = """
           }}
         }}
       }}
-      pullRequests(headRefName: "arhadthedev*", states: OPEN) {{
-        totalCount
-      }}
     }}
 """
 
@@ -80,7 +77,7 @@ subquery_template = """
       ...ContributionsFragment
     }}
     {slug}Pulls: search(
-      query: "repo:{org}/{repo} is:pr is:open author:arhadthedev"
+      query: "repo:{org}/{repo} is:pr is:open author:$user"
       type: ISSUE
       first: 1
     ) {{

--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -115,6 +115,7 @@ async def _make_query(
         gh = GitHubAPI(session, _user_agent, oauth_token=token)
         logger.warning("user: %s", user)
         gh_response = await gh.graphql(query_string, user=user, emails=emails)
+        logger.warning("response: %s", gh_response)
         return user, query_names, gh_response
 
 

--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -77,7 +77,7 @@ subquery_template = """
       ...ContributionsFragment
     }}
     {slug}Pulls: search(
-      query: "repo:{org}/{repo} is:pr is:open author:$user"
+      query: "repo:{org}/{repo} is:pr is:open author:arhadthedev"
       type: ISSUE
       first: 1
     ) {{
@@ -110,12 +110,10 @@ async def _make_query(
     token: str,
 ) -> tuple[str, list[str], NestedDict[str]]:
     query_names, query_string = query
-    logger.warning('A query to be sent: %s', query_string)
+    logger.debug('A query to be sent: %s', query_string)
     async with ClientSession() as session:
         gh = GitHubAPI(session, _user_agent, oauth_token=token)
-        logger.warning("user: %s", user)
         gh_response = await gh.graphql(query_string, user=user, emails=emails)
-        logger.warning("response: %s", gh_response)
         return user, query_names, gh_response
 
 

--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -77,7 +77,7 @@ subquery_template = """
       ...ContributionsFragment
     }}
     {slug}Pulls: search(
-      query: "repo:{org}/{repo} is:pr is:open author:$user"
+      query: "repo:{org}/{repo} is:pr is:open author:arhadthedev"
       type: ISSUE
       first: 1
     ) {{

--- a/github_readme/collect_contribs.py
+++ b/github_readme/collect_contribs.py
@@ -110,7 +110,7 @@ async def _make_query(
     token: str,
 ) -> tuple[str, list[str], NestedDict[str]]:
     query_names, query_string = query
-    logger.info('A query to be sent: %s', query_string)
+    logger.warning('A query to be sent: %s', query_string)
     async with ClientSession() as session:
         gh = GitHubAPI(session, _user_agent, oauth_token=token)
         gh_response = await gh.graphql(query_string, user=user, emails=emails)


### PR DESCRIPTION
We no longer request an empty duplicate of pull requests belonging to a user (it does not work because has no username).

~Also, we no longer hardcode a username for a pull request authorship query parameter.~ Edit: parameter-based string interpolation is not a thing in the current GraphQL version.

- Issue: gh-118