### PR TITLE
gh-118: Simplify pluralization in the report

### DIFF
--- a/github_readme/regen_readme.py
+++ b/github_readme/regen_readme.py
@@ -41,8 +41,8 @@ def _make_contrib_highlight(group: Contribution) -> str | None:
             r'\1' if group.count() == 1 else r'\2',
             group.message_template,
         )
-        markup = f'[{group.message_template}]({group.url})'
-        return plural.format(count=group.count())
+        markup = f'[{plural}]({group.url})'
+        return markup.format(count=group.count())
     return None
 
 


### PR DESCRIPTION
~We no longer describe pluralization like "1 item is/6 items are" case by case, in `Contribution.plural_template`. Instead, we use "1 item( is/s are)" and one `re.sub`.~

Edit: in simple words, we no longer describe pluralization rules like "1 item is/6 items are" manually, in `Contribution.plural_template` for each associated `Contribution.message_template`. Instead, we use one common `re.sub`.

- Issue: gh-118